### PR TITLE
MS-1547 throw exceptions for invalid IDs in generic delegations 

### DIFF
--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -835,15 +835,29 @@ export class IccCryptoXApi {
         this.AES.decrypt(aesKeys[delegation.owner!!], this.utils.hex2ua(delegation.key!!))
           .then((result: ArrayBuffer) => {
             var results = utils.ua2text(result).split(":")
-            // results[0]: must be the ID of the object, for checksum
-            // results[1]: secretForeignKey
-            if (results[0] !== masterId) {
+
+            const objectId = results[0] //must be the ID of the object, for checksum
+            const secretId = results[1]
+
+            const details =
+              "object ID: " +
+              masterId +
+              "; generic delegation from " +
+              delegation.owner +
+              " to " +
+              delegation.delegatedTo
+
+            if (!objectId) console.warn("Object id is empty; " + details)
+            if (!secretId) console.warn("Secret id is empty; " + details)
+
+            if (objectId !== masterId) {
               console.log(
-                "Cryptographic mistake: patient ID is not equal to the concatenated id in SecretForeignKey, this may happen when patients have been merged"
+                "Cryptographic mistake: object ID is not equal to the concatenated id in delegation. This may happen when patients have been merged; " +
+                  details
               )
             }
 
-            return results[1]
+            return secretId
           })
           .catch(err => {
             console.log(


### PR DESCRIPTION
- for create and update scenarios: if methods in icc-crypto-x-api do not receive expected valid IDs (to compose keys that will be encrypted)  then throw exceptions; those exceptions will appear with a lot of details  (method name, parameter values) in the console, probably will break some functionality (visible by QA) and will expose hidden bugs

- for read scenarios: added some more logging to warn to console where invalid keys are found 