### PR TITLE
MS-3554 - Fix access journal: no patient name in the access logs

### DIFF
--- a/icc-x-api/icc-accesslog-x-api.ts
+++ b/icc-x-api/icc-accesslog-x-api.ts
@@ -42,7 +42,8 @@ export class IccAccesslogXApi extends iccAccesslogApi {
         codes: [],
         tags: [],
         user: user.id,
-        accessType: "USER_ACCESS"
+        accessType: "USER_ACCESS",
+        patientId: patient.id
       },
       h || {}
     )


### PR DESCRIPTION
The reason why there was no patient name in the access logs is because no patient id was set in AccessLogDto object used to save the logs