### PR TITLE
[MS-1899] encrypt eh cert

### DIFF
--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -1355,7 +1355,8 @@ export class IccCryptoXApi {
    * Populate the HCP.options dict with an encrypted eHealth certificate and unencryped expiry date.
    * Any potentially unencrypted certificates will be pruned from the HCP.
    * @param hcpId Id of the hcp to modify
-   * @returns modified HCP, without publishing the modifications to the back-end
+   * @returns modified HCP, without publishing the modifications to the back-end. To also publish
+   * the modifications, use the EhAuthenticationService#saveKeyChainInHCPFromLocalStorage
    */
   async saveKeyChainInHCPFromLocalStorage(hcpId: string): Promise<HealthcarePartyDto> {
     return await this.hcpartyBaseApi

--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -106,7 +106,7 @@ export class IccCryptoXApi {
 
   keychainLocalStoreIdPrefix = "org.taktik.icure.ehealth.keychain."
   keychainValidityDateLocalStoreIdPrefix = "org.taktik.icure.ehealth.keychain-date."
-  hcpPreferenceKeyEhealthCertEncrypted = "eHealthCRT_encrypted"
+  hcpPreferenceKeyEhealthCertEncrypted = "eHealthCRTCrypt"
   hcpPreferenceKeyEhealthCertDate = "eHealthCRTDate"
 
   private hcpartyBaseApi: iccHcpartyApi

--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -1431,9 +1431,7 @@ export class IccCryptoXApi {
         console.error("Error while importing the AES key.")
       }
       if (!decryptionKey) {
-        return Promise.reject(
-          new Error("No encryption key! eHealth certificate cannot be decrypted.")
-        )
+        throw new Error("No encryption key! eHealth certificate cannot be decrypted.")
       }
 
       if (!!crtCryp && decryptionKey) {
@@ -1445,11 +1443,9 @@ export class IccCryptoXApi {
       }
 
       if (!crt) {
-        return Promise.reject(
-          new Error(
+        throw new Error(
             `Error while saving certificate in browser local storage! Hcp ${hcp.id} has no certificate.`
-          )
-        )
+          )   
       } else {
         this.saveKeychainInBrowserLocalStorageAsBase64(
           hcp.id!!,
@@ -1457,7 +1453,7 @@ export class IccCryptoXApi {
         )
       }
 
-      return Promise.resolve()
+      return
     })
   }
 


### PR DESCRIPTION
Store the encrypted eHealth certificate and its unencrypted expiry date in the `hcp.options` dict.

The certificate remains encrypted in the back-end and the couch db. It is decrypted only by Medispring front-end app and it is stored in its decrypted form in the browser local storage.

Required for https://github.com/medispring/medispring/pull/3706