### PR TITLE
reintroduce accidentally removed but critical URI encoding

### DIFF
--- a/icc-api/api/iccMessageApi.ts
+++ b/icc-api/api/iccMessageApi.ts
@@ -223,9 +223,9 @@ export class iccMessageApi {
       (transportGuid ? "&transportGuid=" + transportGuid : "") +
       (received ? "&received=" + received : "") +
       (startKey ? "&startKey=" + startKey : "") +
-      (startDocumentId ? "&startDocumentId=" + startDocumentId : "") +
+      (startDocumentId ? "&startDocumentId=" + encodeURIComponent(startDocumentId) : "") + // FIXME: genloc: (startDocumentId ? "&startDocumentId=" + startDocumentId : "") +
       (limit ? "&limit=" + limit : "") +
-      (hcpId ? "&hcpId=" + hcpId : "")
+      (hcpId ? "&hcpId=" + encodeURIComponent(hcpId) : "") // FIXME: genloc:  (hcpId ? "&hcpId=" + hcpId : "")
     let headers = this.headers
     headers = headers
       .filter(h => h.header !== "Content-Type")


### PR DESCRIPTION
also add missing fixme comment that likely caused this accident

This partially reverts commit f7b4515be1aabb63eb6e71ae193eaee7512047da.