### PR TITLE
[tremplin IA] anonymousMedicalInformation sharing and autodelegation

### DIFF
--- a/icc-x-api/icc-contact-x-api.ts
+++ b/icc-x-api/icc-contact-x-api.ts
@@ -113,6 +113,24 @@ export class IccContactXApi extends iccContactApi {
                 })
             ))
         )
+        ;(user.autoDelegations ? user.autoDelegations.anonymousMedicalInformation : []).forEach(
+          delegateId =>
+            (promise = promise.then(contact =>
+              this.crypto
+                .addDelegationsAndEncryptionKeys(
+                  patient,
+                  contact,
+                  hcpId!,
+                  delegateId,
+                  null,
+                  eks.secretId
+                )
+                .catch(e => {
+                  console.log(e)
+                  return contact
+                })
+            ))
+        )
         return promise
       })
   }

--- a/icc-x-api/icc-contact-x-api.ts
+++ b/icc-x-api/icc-contact-x-api.ts
@@ -144,7 +144,9 @@ export class IccContactXApi extends iccContactApi {
         })
       )
       ;(user.autoDelegations
-        ? (user.autoDelegations.all || []).concat(user.autoDelegations.medicalInformation || [])
+        ? (user.autoDelegations.all || [])
+            .concat(user.autoDelegations.medicalInformation || [])
+            .concat(user.autoDelegations.anonymousMedicalInformation || [])
         : []
       ).forEach(
         delegateId =>

--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -967,7 +967,7 @@ export class IccCryptoXApi {
       | models.ReceiptDto,
     ownerId: string,
     delegateId: string,
-    secretDelegationKey: string,
+    secretDelegationKey: string | null,
     secretEncryptionKey: string | null
   ): Promise<
     | models.PatientDto
@@ -992,21 +992,6 @@ export class IccCryptoXApi {
       arguments
     )
 
-    /* This can happen if the document is not linked to a parent but we still want to share the encryption keys (example: a document referenced by its id from a service)
-    this.throwDetailedExceptionForInvalidParameter(
-      "secretDelegationKey",
-      secretDelegationKey,
-      "addDelegationsAndEncryptionKeys",
-      arguments
-    ) */
-
-    /* This can happen if the document is not encrypted
-    this.throwDetailedExceptionForInvalidParameter(
-      "secretEncryptionKey",
-      secretEncryptionKey,
-      "addDelegationsAndEncryptionKeys",
-      arguments
-    ) */
     return (secretDelegationKey
       ? this.extendedDelegationsAndCryptedForeignKeys(
           child,

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -24,7 +24,7 @@ import { utils } from "./crypto/utils"
 import { DelegationDto } from "../icc-api/model/models"
 import { IccCalendarItemXApi } from "./icc-calendar-item-x-api"
 
-enum SharedContent {
+export enum SharedContent {
   ALL = "all",
   ENCRYPTION = "encryption" // for extractor, no delegations, no secret foreign keys, only encryption
 }

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -749,12 +749,14 @@ export class IccPatientXApi extends iccPatientApi {
     const allTags: string[] = _.uniq(_.flatMap(Object.values(delegationTags)))
 
     // Determine which keys to share, depending on the delegation tag. For example, anonymousMedicalData only shares encryption keys and no delegations or secret foreign keys.
-    const shareDelegations: boolean = allTags !== ["anonymousMedicalInformation"]
+    const shareDelegations: boolean = allTags.some(tag => tag != "anonymousMedicalInformation")
     const shareEncryptionKeys: boolean = true
-    const shareCryptedForeignKeys: boolean = allTags !== ["anonymousMedicalInformation"]
+    const shareCryptedForeignKeys: boolean = allTags.some(
+      tag => tag != "anonymousMedicalInformation"
+    )
 
     // Anonymous sharing, will not change anything to the patient, only its contacts and health elements.
-    const shareAnonymously: boolean = allTags === ["anonymousMedicalInformation"]
+    const shareAnonymously: boolean = allTags.every(tag => tag == "anonymousMedicalInformation")
 
     return this.hcpartyApi.getHealthcareParty(ownerId).then(hcp => {
       const parentId = hcp.parentId

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -1030,7 +1030,9 @@ export class IccPatientXApi extends iccPatientApi {
                                   return patient
                                 })
                         })
-                        ;(tags.includes("medicalInformation") || tags.includes("all")) &&
+                        ;(tags.includes("medicalInformation") ||
+                          tags.includes("anonymousMedicalInformation") ||
+                          tags.includes("all")) &&
                           (markerPromise = addDelegationsAndKeys(
                             hes,
                             markerPromise,
@@ -1044,7 +1046,9 @@ export class IccPatientXApi extends iccPatientApi {
                             delegateId,
                             patient
                           ))
-                        ;(tags.includes("medicalInformation") || tags.includes("all")) &&
+                        ;(tags.includes("medicalInformation") ||
+                          tags.includes("anonymousMedicalInformation") ||
+                          tags.includes("all")) &&
                           (markerPromise = addDelegationsAndKeys(
                             ctcsStubs,
                             markerPromise,
@@ -1085,7 +1089,9 @@ export class IccPatientXApi extends iccPatientApi {
                         .then(() => {
                           //console.log("scd")
                           return (
-                            ((allTags.includes("medicalInformation") || allTags.includes("all")) &&
+                            ((allTags.includes("medicalInformation") ||
+                              allTags.includes("anonymousMedicalInformation") ||
+                              allTags.includes("all")) &&
                               (ctcsStubs &&
                                 ctcsStubs.length &&
                                 !_.isEqual(oCtcsStubs, ctcsStubs)) &&
@@ -1102,7 +1108,9 @@ export class IccPatientXApi extends iccPatientApi {
                         .then(() => {
                           //console.log("shed")
                           return (
-                            ((allTags.includes("medicalInformation") || allTags.includes("all")) &&
+                            ((allTags.includes("medicalInformation") ||
+                              allTags.includes("anonymousMedicalInformation") ||
+                              allTags.includes("all")) &&
                               (hes && hes.length && !_.isEqual(oHes, hes)) &&
                               this.helementApi
                                 .setHealthElementsDelegations(hes)

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -757,7 +757,12 @@ export class IccPatientXApi extends iccPatientApi {
       const allTags = _.uniq(_.flatMap(Object.values(delegationTags)))
       const status = {
         contacts: {
-          success: allTags.includes("medicalInformation") || allTags.includes("all") ? false : null,
+          success:
+            allTags.includes("medicalInformation") ||
+            allTags.includes("anonymousMedicalInformation") ||
+            allTags.includes("all")
+              ? false
+              : null,
           error: null,
           modified: 0
         },
@@ -767,7 +772,12 @@ export class IccPatientXApi extends iccPatientApi {
           modified: 0
         },
         healthElements: {
-          success: allTags.includes("medicalInformation") || allTags.includes("all") ? false : null,
+          success:
+            allTags.includes("medicalInformation") ||
+            allTags.includes("anonymousMedicalInformation") ||
+            allTags.includes("all")
+              ? false
+              : null,
           error: null,
           modified: 0
         },


### PR DESCRIPTION
adapt share function of icc-patient-x-api such that when the `anonymousMedicalInformation` tag is used as delegation tag, only encryptionKeys in Contacts and Health elements are shared: no delegations or cryptedForeignKeys, no changes in Patients, Calendar, etc.